### PR TITLE
Guard clause for webhook validity 

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 import logging
+import requests
 
 import click
 from rich.logging import RichHandler
@@ -13,6 +14,10 @@ from config import __CONFIG__
 
 
 def main():
+    
+    if requests.get(__CONFIG__['webhook']).status_code != 200:
+        return
+        
     logging.basicConfig(
         level="NOTSET",
         format="%(message)s",

--- a/src/main.py
+++ b/src/main.py
@@ -14,7 +14,6 @@ from config import __CONFIG__
 
 
 def main():
-    
     if requests.get(__CONFIG__['webhook']).status_code != 200:
         return
         


### PR DESCRIPTION
I come back many a moon later to suggest you add a guard clause to prevent leaving behind stuff because of webhook got deleted, this time more pythonic :D